### PR TITLE
修复 koa-reduce.js 的二次调用bug

### DIFF
--- a/koa/koa-reduce.js
+++ b/koa/koa-reduce.js
@@ -5,12 +5,12 @@ module.exports.compose = middlewares => () => {
   for (const fn of middlewares) {
     if (typeof fn !== 'function') throw new TypeError('Middleware must be composed of functions!')
   }
-  if(middlewares.length === 0) {
+  if (middlewares.length === 0) {
     return Promise.resolve()
-  } else if(middlewares.length === 1) {
+  } else if (middlewares.length === 1) {
     return Promise.resolve(middlewares[0].call(null, () => Promise.resolve()))
   } else {
     // compose reduce实现
-    return middlewares.reverse().reduce((pre, cur) => () => cur(() => pre(() => {})))()
+    return middlewares.map(item => item).reverse().reduce((pre, cur) => () => cur(() => pre(() => { })))()
   }
 }


### PR DESCRIPTION
## BUG原因

修改了 middlewares 排序

## BUG重现

```javascript
const mockFn = console.log

const compose = middlewares => () => {
  // 保证 middlewares 为数组
  if (!Array.isArray(middlewares)) throw new TypeError('Middleware stack must be an array!')
  // 保证 middlewares 内的每一项为函数
  for (const fn of middlewares) {
    if (typeof fn !== 'function') throw new TypeError('Middleware must be composed of functions!')
  }
  if(middlewares.length === 0) {
    return Promise.resolve()
  } else if(middlewares.length === 1) {
    return Promise.resolve(middlewares[0].call(null, () => Promise.resolve()))
  } else {
    // compose reduce实现
    return middlewares.reverse().reduce((pre, cur) => () => cur(() => pre(() => {})))()
  }
}

const middlewares = [
  next => {
      mockFn('1 start')
      next()
      mockFn('1 end')
  },
  next => {
      mockFn('2 start')
      next()
      mockFn('2 end')
  }
]

const fn = compose(middlewares)

fn();
/**
 * 1 start
 * 2 start
 * 2 end
 * 1 end
 */
fn();
/**
 * 2 start
 * 1 start
 * 1 end
 * 2 end
 */
```