### PR TITLE
chore: run test before commit by husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run test

--- a/package.json
+++ b/package.json
@@ -6,11 +6,15 @@
   "scripts": {
     "test": "jest",
     "watch": "jest --watchAll",
-    "coverage": "jest --coverage"
+    "coverage": "jest --coverage",
+    "prepare": "husky install"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "jest": "^26.0.1"
+  },
+  "devDependencies": {
+    "husky": "^7.0.2"
   }
 }


### PR DESCRIPTION
package.json 的 scripts 增加 prepare 命令

prepare 脚本会在npm install（不带参数）之后自动执行。也就是说当我们执行npm install安装完项目依赖后会执行 husky install命令，该命令会创建.husky/目录并指定该目录为git hooks所在的目录。